### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/kr/semanticker/projectboard/domain/Article.java
+++ b/src/main/java/kr/semanticker/projectboard/domain/Article.java
@@ -63,11 +63,11 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Article article = (Article) o;
-        return id != null && getId().equals(article.getId());
+        return this.getId() != null && this.getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/kr/semanticker/projectboard/domain/ArticleComment.java
+++ b/src/main/java/kr/semanticker/projectboard/domain/ArticleComment.java
@@ -49,11 +49,11 @@ public class ArticleComment extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ArticleComment that = (ArticleComment) o;
-        return id != null && Objects.equals(getId(), that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/kr/semanticker/projectboard/domain/UserAccount.java
+++ b/src/main/java/kr/semanticker/projectboard/domain/UserAccount.java
@@ -54,11 +54,11 @@ public class UserAccount extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserAccount that = (UserAccount) o;
-        return Objects.equals(getUserId(), that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
엔티티 비교를 할때  필드를 직접 접근 하여 equals(), hashcode() 사용하던것을
getter를 이용해서 접근하도록 변경.
이는 하이버네이트의 지연로딩으로 동작할때 발생하는 오류를 막아준다.

This closes #56 